### PR TITLE
Trim a newline at end of token

### DIFF
--- a/toggl-now.10s.js
+++ b/toggl-now.10s.js
@@ -82,7 +82,7 @@ function menu(data) {
  * @return {string}
  */
 function loadApiToken() {
-  return fs.readFileSync(CONFIG_FILE_PATH, {encoding: 'utf8'});
+  return fs.readFileSync(CONFIG_FILE_PATH, {encoding: 'utf8'}).trim();
 }
 
 /**


### PR DESCRIPTION
A file may contain a [CR|LF|CR+LF] at the end.